### PR TITLE
Add .npmrc configuration file with minimum release age setting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                       
  - Adds `.npmrc` with `minimum-release-age=10080` (7 days) to prevent installation of newly published packages, mitigating supply chain attacks                                                                   
         