### PR TITLE
Index mainnet LitePSM SellGem/BuyGem events as Swap entities

### DIFF
--- a/abis/psm/DssLitePsm.json
+++ b/abis/psm/DssLitePsm.json
@@ -1,0 +1,52 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "name": "SellGem",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "name": "BuyGem",
+    "type": "event"
+  }
+]

--- a/config.yaml
+++ b/config.yaml
@@ -640,7 +640,6 @@ contracts:
 # === Network Configuration ===
 networks:
   # Ethereum Mainnet (HyperSync)
-  # Ethereum Mainnet (HyperSync)
   - id: 1
     start_block: 8122207
     contracts:

--- a/config.yaml
+++ b/config.yaml
@@ -611,6 +611,22 @@ contracts:
           transaction_fields:
             - hash
 
+  # === LitePSM (mainnet only — wraps sellGem/buyGem for USDC↔USDS 1:1 conversions) ===
+  - name: DssLitePsm
+    handler: src/EventHandlers.ts
+    abi_file_path: abis/psm/DssLitePsm.json
+    events:
+      - event: 'SellGem(address indexed owner, uint256 value, uint256 fee)'
+        field_selection:
+          transaction_fields:
+            - hash
+            - from
+      - event: 'BuyGem(address indexed owner, uint256 value, uint256 fee)'
+        field_selection:
+          transaction_fields:
+            - hash
+            - from
+
   # === Curve Pool ===
   - name: CurveUsdsStUsdsPool
     handler: src/EventHandlers.ts
@@ -623,6 +639,7 @@ contracts:
 
 # === Network Configuration ===
 networks:
+  # Ethereum Mainnet (HyperSync)
   # Ethereum Mainnet (HyperSync)
   - id: 1
     start_block: 8122207
@@ -702,6 +719,9 @@ networks:
       - name: CurveUsdsStUsdsPool
         address:
           - 0x2C7C98A3b1582D83c43987202aEFf638312478aE
+      - name: DssLitePsm
+        address:
+          - 0xf6e72Db5454dd049d0788e411b06CfAF16853042
 
   # Base (HyperSync)
   - id: 8453

--- a/src/EventHandlers.ts
+++ b/src/EventHandlers.ts
@@ -20,6 +20,7 @@ import './rewards';
 
 // === PSM ===
 import './psm3';
+import './lite-psm';
 
 // === Curve ===
 import './curveUsdsStUsdsPool';

--- a/src/lite-psm.ts
+++ b/src/lite-psm.ts
@@ -1,0 +1,57 @@
+import { DssLitePsm } from 'generated';
+
+// Mainnet token addresses
+const USDC_MAINNET = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const USDS_MAINNET = '0xdC035D45d973E3EC169d2276DDab16f1e407384F';
+
+// Conversion factor from USDC (6 decimals) to USDS (18 decimals)
+const TO_18_CONVERSION_FACTOR = BigInt(1e12);
+
+// SellGem: user sells USDC, receives USDS (USDC → USDS)
+// Note: when routed through the usdsPsmWrapper (0xA188...), event.params.owner
+// is the wrapper address, not the user. We use transaction.from for the real user.
+DssLitePsm.SellGem.handler(async ({ event, context }) => {
+  const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;
+  const sender = event.transaction.from ?? '';
+  const usdcAmount = event.params.value;
+  const usdsAmount = usdcAmount * TO_18_CONVERSION_FACTOR;
+
+  context.Swap.set({
+    id,
+    chainId: event.chainId,
+    assetIn: USDC_MAINNET,
+    assetOut: USDS_MAINNET,
+    sender,
+    receiver: sender,
+    amountIn: usdcAmount,
+    amountOut: usdsAmount,
+    referralCode: 0n,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: BigInt(event.block.timestamp),
+    transactionHash: event.transaction.hash,
+  });
+});
+
+// BuyGem: user sells USDS, receives USDC (USDS → USDC)
+// Note: event.params.owner is always the real user here (wrapper passes usr through).
+DssLitePsm.BuyGem.handler(async ({ event, context }) => {
+  const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;
+  const sender = event.transaction.from ?? event.params.owner;
+  const usdcAmount = event.params.value;
+  const usdsAmount = usdcAmount * TO_18_CONVERSION_FACTOR;
+
+  context.Swap.set({
+    id,
+    chainId: event.chainId,
+    assetIn: USDS_MAINNET,
+    assetOut: USDC_MAINNET,
+    sender,
+    receiver: sender,
+    amountIn: usdsAmount,
+    amountOut: usdcAmount,
+    referralCode: 0n,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: BigInt(event.block.timestamp),
+    transactionHash: event.transaction.hash,
+  });
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                          
  - Index mainnet LitePSM (`DssLitePsm` at `0xf6e72Db5...`) `SellGem` and `BuyGem` events as `Swap` entities                                                                                                       
  - Uses `transaction.from` instead of the event's `owner` param to get the real user address (for `SellGem` through the wrapper, `owner` is the wrapper contract `0xA188...`, not the user)                       
  - Reuses the existing `Swap` entity schema — no schema changes needed                                                                                                                                            
  - Converts USDC amounts (6 decimals) to USDS amounts (18 decimals) for the 1:1 conversion
                                                                                                                                                                                                                   
  ## Context                              
                                                                                                                                                                                                                   
  The PSM 1:1 conversion module (USDC↔USDS) was launched on mainnet using the `usdsPsmWrapper` contract, which internally calls the `DssLitePsm` contract. L2 chains use PSM3 contracts that emit `Swap` events    
  already indexed by this repo. Mainnet's LitePSM emits different events (`SellGem`/`BuyGem`) that were not being indexed, creating a gap in on-chain data coverage needed by the analytics reconciliation pipeline
   (api-workers).                                                                                                                                                                                                  
                                          
  ## Changes

  - `abis/psm/DssLitePsm.json` — ABI with SellGem and BuyGem events                                                                                                                                                
  - `src/lite-psm.ts` — Event handler mapping both events to Swap entities
  - `src/EventHandlers.ts` — Register the new handler                                                                                                                                                              
  - `config.yaml` — Add DssLitePsm contract definition with `transaction_fields: [hash, from]` and mainnet address
                                                                                                                                                                                                                   
  ## Known limitations
                                                                                                                                                                                                                   
  - **Account abstraction / multisig**: `transaction.from` will be the bundler or submitting signer, not the smart account. This is a pre-existing limitation across all indexed entities.                         
  - **Aggregator txs**: Direct LitePSM calls from aggregators (OKX, 1inch, etc.) will also be indexed. The downstream reconciliation script scopes by user wallet, so these are filtered out naturally.
                                                                                                                                                                                                                   
  ## Testing                              
                                                                                                                                                                                                                   
  Verified locally against live mainnet data:                                                                                                                                                                      
  - SellGem (USDC→USDS) through wrapper: sender = real user ✓
  - BuyGem (USDS→USDC) through wrapper: sender = real user ✓                                                                                                                                                       
  - Amounts correctly converted between 6 and 18 decimals ✓