### PR TITLE
Add StusdsCut event handling and schema definition

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -328,6 +328,10 @@ contracts:
         field_selection:
           transaction_fields:
             - hash
+      - event: 'Cut(uint256 assets, uint256 oldChi, uint256 newChi)'
+        field_selection:
+          transaction_fields:
+            - hash
 
   # === Token Conversions ===
   - name: DaiUsds

--- a/schema.graphql
+++ b/schema.graphql
@@ -1097,6 +1097,17 @@ type StusdsReferral {
   transactionHash: String!
 }
 
+type StusdsCut {
+  id: ID!
+  chainId: Int! @index
+  assets: BigInt!
+  oldChi: BigInt!
+  newChi: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: String!
+}
+
 type CurveTokenExchange {
   id: ID!
   chainId: Int! @index

--- a/src/stusds.ts
+++ b/src/stusds.ts
@@ -48,3 +48,18 @@ Stusds.Referral.handler(async ({ event, context }) => {
     transactionHash: event.transaction.hash,
   });
 });
+
+Stusds.Cut.handler(async ({ event, context }) => {
+  const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;
+
+  context.StusdsCut.set({
+    id,
+    chainId: event.chainId,
+    assets: event.params.assets,
+    oldChi: event.params.oldChi,
+    newChi: event.params.newChi,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: BigInt(event.block.timestamp),
+    transactionHash: event.transaction.hash,
+  });
+});


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                                                                        
  - Adds the `Cut(uint256 assets, uint256 oldChi, uint256 newChi)` event to the `Stusds` contract config, a matching `StusdsCut` entity in `schema.graphql`, and a handler in `src/stusds.ts` that mirrors the existing `Deposit`/`Withdraw`/`Referral` handlers.                                                                                   
  - Enables the app to query slashing history on the stUSDS pool (follow-up: frontend consumes `StusdsCut` to render in pool history).                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                    
  Closes [APP-17](https://linear.app/skybasestar/issue/APP-17/add-support-for-slashing-cut-events-on-stusds-pool).                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                                                                                                                                                                                      
  - [ ] `pnpm codegen` succeeds                                                                                                                                                                                                                                                                                                                     
  - [ ] `pnpm dev` syncs mainnet without errors; `StusdsCut` table present in Hasura
  - [ ] `StusdsCut_aggregate { count }` returns `0` (no `cut()` calls have occurred on mainnet — verified via `eth_getLogs` on topic `0xaaa7de6dcd0061e0bcd3a9bb711f1cc6d76b603c4d5cb97901525c7952076406`)
  - [ ] Existing `StusdsDeposit` / `StusdsWithdraw` / `StusdsReferral` counts continue to grow (regression check)              