### PR TITLE
Upgrade to pnpm 11.5.0 + add 1-week minimum-release-age

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "sky-money-indexer",
+  "packageManager": "pnpm@11.5.0",
   "scripts": {
     "codegen": "envio codegen",
     "codegen:tenderly": "envio codegen --config config.tenderly.yaml",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# Delay installing newly published versions to reduce supply-chain risk.
+# Value is in minutes; 10080 = 1 week (7 * 24 * 60).
+minimumReleaseAge: 10080
+
+# Dependencies allowed to run install/build scripts (pnpm v11 replaces
+# onlyBuiltDependencies with this map). Both are required by Envio:
+# rescript compiles the ReScript toolchain, esbuild fetches its native binary.
+allowBuilds:
+  esbuild: true
+  rescript: true


### PR DESCRIPTION
Closes APP-242.

## What changed
- **Pin pnpm**: added `"packageManager": "pnpm@11.5.0"` to `package.json` (first time this repo pins it, getting onto the Corepack pattern used by the other repos).
- **Supply-chain delay**: new `pnpm-workspace.yaml` with `minimumReleaseAge: 10080` — 1 week, expressed in minutes (`7 * 24 * 60`). In pnpm v11 this setting only lives in `pnpm-workspace.yaml` (not `.npmrc`).
- **`allowBuilds`**: explicitly allow `esbuild` and `rescript` to run install/build scripts. Reinstalling under the new layout surfaced `ERR_PNPM_IGNORED_BUILDS` for both; they're required by Envio (ReScript toolchain + esbuild native binary). pnpm v11 replaces `onlyBuiltDependencies` with this map.

## Verification
- pnpm reports **11.5.0**
- `pnpm install` — lockfile **unchanged**, no resolver drift (`pnpm-lock.yaml` not in diff)
- Supply-chain policy active: *"✓ Lockfile passes supply-chain policies (202 entries)"*
- `pnpm codegen` (Envio HyperIndex + ReScript compile) — pass
- `pnpm tsc --noEmit` — clean (TS 5.9.3)

## Not included
- **CI workflows**: none exist in this repo (`.github/` only has `dependabot.yml`, which has no pnpm version reference), so there was nothing to update there.
- **Local indexer run (`pnpm dev`)**: skipped (needs Docker / long-running). Codegen + typecheck pass.
- **Pending Dependabot bumps** (ts 5→6, viem, @types/node): left out to keep this diff scoped to the pnpm upgrade.