### PR TITLE
Add sUSDT vault event tracking

### DIFF
--- a/abis/maker/Susdt.json
+++ b/abis/maker/Susdt.json
@@ -1,0 +1,1667 @@
+[
+	{
+		"type": "constructor",
+		"inputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "AccessControlBadConfirmation",
+		"type": "error",
+		"inputs": []
+	},
+	{
+		"name": "AccessControlUnauthorizedAccount",
+		"type": "error",
+		"inputs": [
+			{
+				"name": "account",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "neededRole",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		]
+	},
+	{
+		"name": "AddressEmptyCode",
+		"type": "error",
+		"inputs": [
+			{
+				"name": "target",
+				"type": "address",
+				"internalType": "address"
+			}
+		]
+	},
+	{
+		"name": "ERC1967InvalidImplementation",
+		"type": "error",
+		"inputs": [
+			{
+				"name": "implementation",
+				"type": "address",
+				"internalType": "address"
+			}
+		]
+	},
+	{
+		"name": "ERC1967NonPayable",
+		"type": "error",
+		"inputs": []
+	},
+	{
+		"name": "FailedCall",
+		"type": "error",
+		"inputs": []
+	},
+	{
+		"name": "InvalidInitialization",
+		"type": "error",
+		"inputs": []
+	},
+	{
+		"name": "NotInitializing",
+		"type": "error",
+		"inputs": []
+	},
+	{
+		"name": "SafeERC20FailedOperation",
+		"type": "error",
+		"inputs": [
+			{
+				"name": "token",
+				"type": "address",
+				"internalType": "address"
+			}
+		]
+	},
+	{
+		"name": "UUPSUnauthorizedCallContext",
+		"type": "error",
+		"inputs": []
+	},
+	{
+		"name": "UUPSUnsupportedProxiableUUID",
+		"type": "error",
+		"inputs": [
+			{
+				"name": "slot",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		]
+	},
+	{
+		"name": "Approval",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "owner",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "spender",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "Deposit",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "sender",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "owner",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "assets",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			},
+			{
+				"name": "shares",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "DepositCapSet",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "oldCap",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			},
+			{
+				"name": "newCap",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "Drip",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "chi",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			},
+			{
+				"name": "diff",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "Initialized",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "version",
+				"type": "uint64",
+				"indexed": false,
+				"internalType": "uint64"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "Referral",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "referral",
+				"type": "uint16",
+				"indexed": true,
+				"internalType": "uint16"
+			},
+			{
+				"name": "owner",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "assets",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			},
+			{
+				"name": "shares",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "RoleAdminChanged",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"indexed": true,
+				"internalType": "bytes32"
+			},
+			{
+				"name": "previousAdminRole",
+				"type": "bytes32",
+				"indexed": true,
+				"internalType": "bytes32"
+			},
+			{
+				"name": "newAdminRole",
+				"type": "bytes32",
+				"indexed": true,
+				"internalType": "bytes32"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "RoleGranted",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"indexed": true,
+				"internalType": "bytes32"
+			},
+			{
+				"name": "account",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "sender",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "RoleRevoked",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"indexed": true,
+				"internalType": "bytes32"
+			},
+			{
+				"name": "account",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "sender",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "Take",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "to",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "Transfer",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "from",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "to",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "Upgraded",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "implementation",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "VsrBoundsSet",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "oldMinVsr",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			},
+			{
+				"name": "oldMaxVsr",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			},
+			{
+				"name": "newMinVsr",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			},
+			{
+				"name": "newMaxVsr",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "VsrSet",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "sender",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "oldVsr",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			},
+			{
+				"name": "newVsr",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "Withdraw",
+		"type": "event",
+		"inputs": [
+			{
+				"name": "sender",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "receiver",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "owner",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "assets",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			},
+			{
+				"name": "shares",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
+		"name": "DEFAULT_ADMIN_ROLE",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "DOMAIN_SEPARATOR",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "MAX_VSR",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "PERMIT_TYPEHASH",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "RAY",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "SETTER_ROLE",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "TAKER_ROLE",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "UPGRADE_INTERFACE_VERSION",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "string",
+				"internalType": "string"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "allowance",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "approve",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "spender",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool",
+				"internalType": "bool"
+			}
+		],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "asset",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "assetsOf",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "owner",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "assetsOutstanding",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "balanceOf",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "chi",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint192",
+				"internalType": "uint192"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "convertToAssets",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "shares",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "convertToShares",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "assets",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "decimals",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint8",
+				"internalType": "uint8"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "deposit",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "assets",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "receiver",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "shares",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "deposit",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "assets",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "receiver",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "referral",
+				"type": "uint16",
+				"internalType": "uint16"
+			}
+		],
+		"outputs": [
+			{
+				"name": "shares",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "depositCap",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "drip",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "nChi",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "getImplementation",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "getRoleAdmin",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "getRoleMember",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			},
+			{
+				"name": "index",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "getRoleMemberCount",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "getRoleMembers",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "address[]",
+				"internalType": "address[]"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "grantRole",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			},
+			{
+				"name": "account",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "hasRole",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			},
+			{
+				"name": "account",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool",
+				"internalType": "bool"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "initialize",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "asset_",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "name_",
+				"type": "string",
+				"internalType": "string"
+			},
+			{
+				"name": "symbol_",
+				"type": "string",
+				"internalType": "string"
+			},
+			{
+				"name": "admin",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "maxDeposit",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "maxMint",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "maxRedeem",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "owner",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "maxVsr",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "maxWithdraw",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "owner",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "minVsr",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "mint",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "shares",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "receiver",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "referral",
+				"type": "uint16",
+				"internalType": "uint16"
+			}
+		],
+		"outputs": [
+			{
+				"name": "assets",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "mint",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "shares",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "receiver",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "assets",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "name",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "string",
+				"internalType": "string"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "nonces",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "nowChi",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "permit",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "owner",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "spender",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "deadline",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "signature",
+				"type": "bytes",
+				"internalType": "bytes"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "permit",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "owner",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "spender",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "deadline",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "v",
+				"type": "uint8",
+				"internalType": "uint8"
+			},
+			{
+				"name": "r",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			},
+			{
+				"name": "s",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "previewDeposit",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "assets",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "previewMint",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "shares",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "previewRedeem",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "shares",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "amount",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "previewWithdraw",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "assets",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "proxiableUUID",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "redeem",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "shares",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "receiver",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "owner",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "assets",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "renounceRole",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			},
+			{
+				"name": "callerConfirmation",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "revokeRole",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "role",
+				"type": "bytes32",
+				"internalType": "bytes32"
+			},
+			{
+				"name": "account",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "rho",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint64",
+				"internalType": "uint64"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "setDepositCap",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "newCap",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "setVsr",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "newVsr",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "setVsrBounds",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "minVsr_",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "maxVsr_",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "supportsInterface",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "interfaceId",
+				"type": "bytes4",
+				"internalType": "bytes4"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool",
+				"internalType": "bool"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "symbol",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "string",
+				"internalType": "string"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "take",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "value",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "totalAssets",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "totalSupply",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "transfer",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "to",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool",
+				"internalType": "bool"
+			}
+		],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "transferFrom",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "from",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "to",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool",
+				"internalType": "bool"
+			}
+		],
+		"stateMutability": "nonpayable"
+	},
+	{
+		"name": "upgradeToAndCall",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "newImplementation",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "data",
+				"type": "bytes",
+				"internalType": "bytes"
+			}
+		],
+		"outputs": [],
+		"stateMutability": "payable"
+	},
+	{
+		"name": "version",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "string",
+				"internalType": "string"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "vsr",
+		"type": "function",
+		"inputs": [],
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "view"
+	},
+	{
+		"name": "withdraw",
+		"type": "function",
+		"inputs": [
+			{
+				"name": "assets",
+				"type": "uint256",
+				"internalType": "uint256"
+			},
+			{
+				"name": "receiver",
+				"type": "address",
+				"internalType": "address"
+			},
+			{
+				"name": "owner",
+				"type": "address",
+				"internalType": "address"
+			}
+		],
+		"outputs": [
+			{
+				"name": "shares",
+				"type": "uint256",
+				"internalType": "uint256"
+			}
+		],
+		"stateMutability": "nonpayable"
+	}
+]

--- a/config.tenderly.yaml
+++ b/config.tenderly.yaml
@@ -315,6 +315,23 @@ contracts:
           transaction_fields:
             - hash
 
+  - name: Susdt
+    handler: src/EventHandlers.ts
+    abi_file_path: abis/maker/Susdt.json
+    events:
+      - event: 'Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Referral(uint16 indexed referral, address indexed owner, uint256 assets, uint256 shares)'
+        field_selection:
+          transaction_fields:
+            - hash
+
   # === Token Conversions ===
   - name: DaiUsds
     handler: src/EventHandlers.ts
@@ -683,6 +700,9 @@ networks:
       - name: Stusds
         address:
           - 0x99CD4Ec3f88A45940936F469E4bB72A2A701EEB9
+      - name: Susdt
+        address:
+          - 0x74cb54e082411cfCAEADb00a0765625B10410DAa
       - name: DaiUsds
         address:
           - 0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A

--- a/config.yaml
+++ b/config.yaml
@@ -329,6 +329,23 @@ contracts:
           transaction_fields:
             - hash
 
+  - name: Susdt
+    handler: src/EventHandlers.ts
+    abi_file_path: abis/maker/Susdt.json
+    events:
+      - event: 'Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Referral(uint16 indexed referral, address indexed owner, uint256 assets, uint256 shares)'
+        field_selection:
+          transaction_fields:
+            - hash
+
   # === Token Conversions ===
   - name: DaiUsds
     handler: src/EventHandlers.ts
@@ -675,6 +692,9 @@ networks:
       - name: Stusds
         address:
           - 0x99CD4Ec3f88A45940936F469E4bB72A2A701EEB9
+      - name: Susdt
+        address:
+          - 0x74cb54e082411cfCAEADb00a0765625B10410DAa
       - name: DaiUsds
         address:
           - 0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A

--- a/schema.graphql
+++ b/schema.graphql
@@ -1101,7 +1101,7 @@ type SusdtDeposit {
   id: ID!
   chainId: Int! @index
   sender: String!
-  owner: String!
+  owner: String! @index
   assets: BigInt!
   shares: BigInt!
   blockNumber: BigInt!
@@ -1114,7 +1114,7 @@ type SusdtWithdraw {
   chainId: Int! @index
   sender: String!
   receiver: String!
-  owner: String!
+  owner: String! @index
   assets: BigInt!
   shares: BigInt!
   blockNumber: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -1097,6 +1097,43 @@ type StusdsReferral {
   transactionHash: String!
 }
 
+type SusdtDeposit {
+  id: ID!
+  chainId: Int! @index
+  sender: String!
+  owner: String!
+  assets: BigInt!
+  shares: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: String!
+}
+
+type SusdtWithdraw {
+  id: ID!
+  chainId: Int! @index
+  sender: String!
+  receiver: String!
+  owner: String!
+  assets: BigInt!
+  shares: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: String!
+}
+
+type SusdtReferral {
+  id: ID!
+  chainId: Int! @index
+  referral: Int!
+  owner: String!
+  assets: BigInt!
+  shares: BigInt!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: String!
+}
+
 type CurveTokenExchange {
   id: ID!
   chainId: Int! @index

--- a/src/EventHandlers.ts
+++ b/src/EventHandlers.ts
@@ -14,6 +14,7 @@ import './mkr-sky-v2';
 // === Savings & Staking ===
 import './savings-usds';
 import './stusds';
+import './susdt';
 
 // === Rewards ===
 import './rewards';

--- a/src/susdt.ts
+++ b/src/susdt.ts
@@ -1,0 +1,50 @@
+import { Susdt } from 'generated';
+
+Susdt.Deposit.handler(async ({ event, context }) => {
+  const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;
+
+  context.SusdtDeposit.set({
+    id,
+    chainId: event.chainId,
+    sender: event.params.sender,
+    owner: event.params.owner,
+    assets: event.params.assets,
+    shares: event.params.shares,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: BigInt(event.block.timestamp),
+    transactionHash: event.transaction.hash,
+  });
+});
+
+Susdt.Withdraw.handler(async ({ event, context }) => {
+  const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;
+
+  context.SusdtWithdraw.set({
+    id,
+    chainId: event.chainId,
+    sender: event.params.sender,
+    receiver: event.params.receiver,
+    owner: event.params.owner,
+    assets: event.params.assets,
+    shares: event.params.shares,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: BigInt(event.block.timestamp),
+    transactionHash: event.transaction.hash,
+  });
+});
+
+Susdt.Referral.handler(async ({ event, context }) => {
+  const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;
+
+  context.SusdtReferral.set({
+    id,
+    chainId: event.chainId,
+    referral: Number(event.params.referral),
+    owner: event.params.owner,
+    assets: event.params.assets,
+    shares: event.params.shares,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: BigInt(event.block.timestamp),
+    transactionHash: event.transaction.hash,
+  });
+});


### PR DESCRIPTION
## Summary

Adds indexing for the new **sUSDT** vault (SparkVault, ERC-4626) — the USDT counterpart to sUSDS/stUSDS.

- **Contract**: `0x74cb54e082411cfCAEADb00a0765625B10410DAa` (ERC-1967 proxy, Ethereum mainnet), implementation `SparkVault` at `0x1b992302652A92611DCd5090D1Cb388C6377f455`
- **Events tracked**: `Deposit`, `Withdraw`, `Referral` — same signatures and scope as sUSDS/stUSDS
- **Entities**: `SusdtDeposit`, `SusdtWithdraw`, `SusdtReferral`
- Added to both `config.yaml` and `config.tenderly.yaml` (keeps shared generated types consistent)

## Changes

- `abis/maker/Susdt.json` — implementation ABI (verified, pulled via Sourcify proxy resolution)
- `config.yaml` / `config.tenderly.yaml` — `Susdt` contract definition + mainnet address
- `schema.graphql` — 3 new entities following the `Stusds*` conventions
- `src/susdt.ts` — handlers modeled on `src/stusds.ts`, registered in `src/EventHandlers.ts`

## Validation

- `pnpm codegen` ✅ (both default and `codegen:tenderly`)
- `pnpm tsc --noEmit` ✅