### PR TITLE
Fix Tenderly indexer: add Stusds.Cut + DssLitePsm to tenderly config

### DIFF
--- a/config.tenderly.yaml
+++ b/config.tenderly.yaml
@@ -314,6 +314,10 @@ contracts:
         field_selection:
           transaction_fields:
             - hash
+      - event: 'Cut(uint256 assets, uint256 oldChi, uint256 newChi)'
+        field_selection:
+          transaction_fields:
+            - hash
 
   - name: Susdt
     handler: src/EventHandlers.ts
@@ -603,6 +607,22 @@ contracts:
         field_selection:
           transaction_fields:
             - hash
+
+  # === LitePSM (not deployed on Tenderly but needed for shared generated types) ===
+  - name: DssLitePsm
+    handler: src/EventHandlers.ts
+    abi_file_path: abis/psm/DssLitePsm.json
+    events:
+      - event: 'SellGem(address indexed owner, uint256 value, uint256 fee)'
+        field_selection:
+          transaction_fields:
+            - hash
+            - from
+      - event: 'BuyGem(address indexed owner, uint256 value, uint256 fee)'
+        field_selection:
+          transaction_fields:
+            - hash
+            - from
 
   # === Governance: Arbitrum Polling (not deployed on Tenderly but needed for shared generated types) ===
   - name: PollingEmitterArbitrum


### PR DESCRIPTION
## Problem

The Tenderly indexer (staging) was crash-looping at startup with a TypeScript compile error:

```
src/stusds.ts(52,8): error TS2339: Property 'Cut' does not exist on type
  '{ Deposit: {...}; Withdraw: {...}; Referral: {...}; }'.
```

## Cause

`src/stusds.ts` and `src/lite-psm.ts` came in from `main` and reference `Stusds.Cut` and the `DssLitePsm` contract. Those were added to `config.yaml` but **not** `config.tenderly.yaml`. Handler files are shared across both configs, so the Tenderly build generates its types from `config.tenderly.yaml` — missing `Cut`/`DssLitePsm` → the shared handlers fail to compile.

This is the same class of issue the earlier "Add Psm3 and PollingEmitterArbitrum to Tenderly config for shared generated types" change addressed.

## Fix

Add to `config.tenderly.yaml`, mirroring `config.yaml`:
- `Cut(uint256 assets, uint256 oldChi, uint256 newChi)` event on the `Stusds` contract
- `DssLitePsm` contract definition (`SellGem` / `BuyGem`) — definition-only, not indexed on Tenderly, matching the `PollingEmitterArbitrum` precedent

## Validation

- `pnpm codegen:tenderly` → ReScript compiles 124/124 ✅
- `pnpm tsc --noEmit` → clean ✅

Since PR #31 (`staging → main`) is still open with `staging` as its head, merging this into `staging` will automatically carry the fix into #31, keeping `main` consistent too.