### PR TITLE
Staging > main

### DIFF
--- a/abis/rewards/RewardsUsdsGrove.json
+++ b/abis/rewards/RewardsUsdsGrove.json
@@ -1,0 +1,459 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "_rewardsDistribution",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "_rewardsToken", "type": "address" },
+      { "internalType": "address", "name": "_stakingToken", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerNominated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "PauseChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Recovered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint16",
+        "name": "referral",
+        "type": "uint16"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Referral",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardPaid",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newRewardsDistribution",
+        "type": "address"
+      }
+    ],
+    "name": "RewardsDistributionUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardsDurationUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Staked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdrawn",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "earned",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRewardForDuration",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastPauseTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastTimeRewardApplicable",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastUpdateTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" }
+    ],
+    "name": "nominateNewOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nominatedOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "reward", "type": "uint256" }
+    ],
+    "name": "notifyRewardAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "periodFinish",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "uint256", "name": "tokenAmount", "type": "uint256" }
+    ],
+    "name": "recoverERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardPerToken",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardPerTokenStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "rewards",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardsDistribution",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardsDuration",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardsToken",
+    "outputs": [
+      { "internalType": "contract IERC20", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bool", "name": "_paused", "type": "bool" }],
+    "name": "setPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_rewardsDistribution",
+        "type": "address"
+      }
+    ],
+    "name": "setRewardsDistribution",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_rewardsDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "setRewardsDuration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "uint16", "name": "referral", "type": "uint16" }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakingToken",
+    "outputs": [
+      { "internalType": "contract IERC20", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "userRewardPerTokenPaid",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/config.tenderly.yaml
+++ b/config.tenderly.yaml
@@ -278,6 +278,27 @@ contracts:
           transaction_fields:
             - hash
 
+  - name: RewardsUsdsGrove
+    handler: src/EventHandlers.ts
+    abi_file_path: abis/rewards/RewardsUsdsGrove.json
+    events:
+      - event: 'RewardPaid(address indexed user, uint256 reward)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Staked(address indexed user, uint256 amount)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Withdrawn(address indexed user, uint256 amount)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Referral(uint16 indexed referral, address indexed user, uint256 amount)'
+        field_selection:
+          transaction_fields:
+            - hash
+
   # === Savings & Staking ===
   - name: SavingsUsds
     handler: src/EventHandlers.ts
@@ -713,6 +734,9 @@ chains:
       - name: RewardsLsskySky
         address:
           - 0xB44C2Fb4181D7Cb06bdFf34A46FdFe4a259B40Fc
+      - name: RewardsUsdsGrove
+        address:
+          - 0x4E41488C19cD35EB4de3083Fc3e204854c75c86a
       - name: SavingsUsds
         address:
           - 0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD

--- a/config.tenderly.yaml
+++ b/config.tenderly.yaml
@@ -682,7 +682,7 @@ chains:
   # Tenderly Testnet (RPC fallback)
   - id: 314310
     rpc:
-      - url: https://virtual.rpc.tenderly.co/${ENVIO_TENDERLY_TESTNET_PATH}
+      - url: https://virtual.mainnet.eu.rpc.tenderly.co/${ENVIO_TENDERLY_TESTNET_PATH}
         for: sync
         initial_block_interval: 2000
         interval_ceiling: 5000

--- a/config.yaml
+++ b/config.yaml
@@ -292,6 +292,27 @@ contracts:
           transaction_fields:
             - hash
 
+  - name: RewardsUsdsGrove
+    handler: src/EventHandlers.ts
+    abi_file_path: abis/rewards/RewardsUsdsGrove.json
+    events:
+      - event: 'RewardPaid(address indexed user, uint256 reward)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Staked(address indexed user, uint256 amount)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Withdrawn(address indexed user, uint256 amount)'
+        field_selection:
+          transaction_fields:
+            - hash
+      - event: 'Referral(uint16 indexed referral, address indexed user, uint256 amount)'
+        field_selection:
+          transaction_fields:
+            - hash
+
   # === Savings & Staking ===
   - name: SavingsUsds
     handler: src/EventHandlers.ts
@@ -704,6 +725,9 @@ chains:
       - name: RewardsLsskySky
         address:
           - 0xB44C2Fb4181D7Cb06bdFf34A46FdFe4a259B40Fc
+      - name: RewardsUsdsGrove
+        address:
+          - 0x4E41488C19cD35EB4de3083Fc3e204854c75c86a
       - name: SavingsUsds
         address:
           - 0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD

--- a/src/helpers/contractCalls.ts
+++ b/src/helpers/contractCalls.ts
@@ -76,7 +76,7 @@ const curveCoinsAbi = [
 const RPC_URLS: Record<number, string> = {
   1: process.env.ENVIO_MAINNET_RPC_URL || '',
   314310:
-    `https://virtual.rpc.tenderly.co/${process.env.ENVIO_TENDERLY_TESTNET_PATH}` ||
+    `https://virtual.mainnet.eu.rpc.tenderly.co/${process.env.ENVIO_TENDERLY_TESTNET_PATH}` ||
     '',
 };
 

--- a/src/rewards.ts
+++ b/src/rewards.ts
@@ -10,6 +10,7 @@ type RewardsContract =
   | 'RewardsLsskyUsds'
   | 'RewardsLsskySpk'
   | 'RewardsLsskySky'
+  | 'RewardsUsdsGrove'
   | 'RewardsUsdsClePoints';
 
 // Helper: get or initialize a Reward entity
@@ -284,6 +285,20 @@ indexer.onEvent({ contract: 'RewardsLsskySky', event: 'Withdrawn' }, async ({ ev
   await handleRewardWithdrawn(event, context);
 });
 indexer.onEvent({ contract: 'RewardsLsskySky', event: 'Referral' }, async ({ event, context }) => {
+  await handleRewardReferral(event, context);
+});
+
+// --- RewardsUsdsGrove ---
+indexer.onEvent({ contract: 'RewardsUsdsGrove', event: 'RewardPaid' }, async ({ event, context }) => {
+  await handleRewardClaimed(event, context);
+});
+indexer.onEvent({ contract: 'RewardsUsdsGrove', event: 'Staked' }, async ({ event, context }) => {
+  await handleRewardSupplied(event, context);
+});
+indexer.onEvent({ contract: 'RewardsUsdsGrove', event: 'Withdrawn' }, async ({ event, context }) => {
+  await handleRewardWithdrawn(event, context);
+});
+indexer.onEvent({ contract: 'RewardsUsdsGrove', event: 'Referral' }, async ({ event, context }) => {
   await handleRewardReferral(event, context);
 });
 


### PR DESCRIPTION
Release of the Grove farm indexing ahead of the GROVE TGE launch:

- Add the `RewardsUsdsGrove` StakingRewards contract (`0x4E41488C19cD35EB4de3083Fc3e204854c75c86a`) to both the mainnet (`config.yaml`) and Tenderly (`config.tenderly.yaml`) configs, with its ABI and event handlers (Staked / Withdrawn / RewardPaid) wired into the shared rewards handler
- Update the Tenderly testnet RPC to the new EU-region fixed URL (the old regionless URL points at a stale fork)

Already validated end-to-end on the Tenderly indexer deployment (`1ad7bb2`, promoted): supply, withdraw, and claim events for the Grove farm index correctly and surface in the webapp (TVL, totals, and transaction history).

After merge: wait for the new Envio deployment to sync (~25–30 min), then promote it to prod in the sky-money-indexer project.