### PR TITLE
chore: upgrade HyperIndex to envio@3.2.1

### DIFF
--- a/.claude/skills/envio-docs/SKILL.md
+++ b/.claude/skills/envio-docs/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: envio-docs
+description: >-
+  Use when something is unclear, confusing, or not covered by other skills.
+  Search and read the latest Envio documentation without leaving the terminal.
+metadata:
+  managed-by: envio
+---
+
+- `envio tools search-docs "<query>"` — find docs pages by keyword
+- `envio tools fetch-docs <url>` — read a page in full (use a URL from search results)
+- `envio --help` — list available CLI commands and flags
+
+Example: `envio tools search-docs "schema derivedFrom"` → pick a URL → `envio tools fetch-docs <url>`

--- a/.claude/skills/indexer-blocks/SKILL.md
+++ b/.claude/skills/indexer-blocks/SKILL.md
@@ -68,6 +68,4 @@ indexer.onBlock(
 - If `where` returns `false` for every configured chain, a warning is logged at registration time
 - For per-event startBlock (not stride), use `indexer.onEvent` with `where.block.number._gte` (see `indexer-filters`). Event filters accept `_gte` only; `_lte`/`_every` are reserved for `onBlock`.
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-configuration/SKILL.md
+++ b/.claude/skills/indexer-configuration/SKILL.md
@@ -151,6 +151,4 @@ Add at top of file for IDE schema validation:
 
 RPC tuning parameters are documented in the `indexer-performance` skill.
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-external-calls/SKILL.md
+++ b/.claude/skills/indexer-external-calls/SKILL.md
@@ -90,4 +90,4 @@ const getTokenMetadata = createEffect(
 | `cache` | `boolean` | `false` |
 | `rateLimit` | `false \| { calls, per }` | required |
 
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-factory/SKILL.md
+++ b/.claude/skills/indexer-factory/SKILL.md
@@ -77,6 +77,4 @@ NftFactory.SimpleNftCreated.contractRegister(async ({ event, context }) => {
 
 When a dynamic contract is registered, the Envio Indexer indexes all events from that contract in the **same block** where it was created — even events from earlier transactions in that block.
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-filters/SKILL.md
+++ b/.claude/skills/indexer-filters/SKILL.md
@@ -160,6 +160,4 @@ On Fuel, key the block range on `block.height` instead of `block.number`. SVM ha
 - `return false` → skip the chain entirely (no events processed for that chain)
 - `return true` → accept all events (no filtering, default topic0-only selection)
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-handlers/SKILL.md
+++ b/.claude/skills/indexer-handlers/SKILL.md
@@ -54,13 +54,15 @@ const list = await context.Entity.getWhere({ fieldName: { _lt: value } });
 const list = await context.Entity.getWhere({ fieldName: { _gte: value } });
 const list = await context.Entity.getWhere({ fieldName: { _lte: value } });
 const list = await context.Entity.getWhere({ fieldName: { _in: [value1, value2] } });
+const list = await context.Entity.getWhere({ fieldName: { _gte: min, _lte: max } });
+const list = await context.Entity.getWhere({ fieldA: { _eq: a }, fieldB: { _eq: b } });
 
 // Write
 context.Entity.set(entity);          // create or update (sync — no await)
 context.Entity.deleteUnsafe(id);     // delete (sync — no await)
 ```
 
-`getWhere` operators: `_eq`, `_gt`, `_lt`, `_gte`, `_lte`, `_in`. Only `@index` fields are queryable. See `indexer-schema` for @index syntax.
+`getWhere` operators: `_eq`, `_gt`, `_lt`, `_gte`, `_lte`, `_in`. Multiple fields and operators combine with AND semantics. Only `id` and `@index` fields are queryable. See `indexer-schema` for @index syntax.
 
 ### Context Properties
 
@@ -126,6 +128,4 @@ This is globally unique across chains and blocks. Use it as the default unless t
 
 **Schema & config** — see `indexer-schema` and `indexer-configuration` skills for full reference.
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-multichain/SKILL.md
+++ b/.claude/skills/indexer-multichain/SKILL.md
@@ -64,6 +64,4 @@ chains:
           - 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174
 ```
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-performance/SKILL.md
+++ b/.claude/skills/indexer-performance/SKILL.md
@@ -66,6 +66,4 @@ rpc:
 
 Add `@index` to schema fields for faster queries — see `indexer-schema` for full syntax (single-field, composite, DESC direction).
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-schema/SKILL.md
+++ b/.claude/skills/indexer-schema/SKILL.md
@@ -96,7 +96,7 @@ type Trade @index(fields: ["poolId", ["date", "DESC"]]) {
 
 - Fields default to ASC; use `["field", "DESC"]` for descending
 - IDs and `@derivedFrom` fields are automatically indexed
-- Only `@index` fields are queryable via `context.Entity.getWhere()`
+- Only `id` and `@index` fields are queryable via `context.Entity.getWhere()`
 
 ## @config
 
@@ -163,6 +163,4 @@ type Swap {
 
 Codegen always appends `_id` to entity reference field names in the TypeScript types. Do **not** add `_id` yourself in the schema.
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-testing/SKILL.md
+++ b/.claude/skills/indexer-testing/SKILL.md
@@ -165,8 +165,4 @@ curl --request POST \
 
 Returns the earliest matching blocks. Use `from_block` to paginate forward. Pick a tight range (50–200 blocks) for fast, deterministic tests.
 
-Full HyperSync query reference: https://docs.envio.dev/docs/HyperSync-LLM/hypersync-complete
-
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-traces/SKILL.md
+++ b/.claude/skills/indexer-traces/SKILL.md
@@ -54,6 +54,4 @@ const getTraces = createEffect(
 );
 ```
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-transactions/SKILL.md
+++ b/.claude/skills/indexer-transactions/SKILL.md
@@ -60,6 +60,4 @@ Block fields are also configurable via `block_fields`. Default: `number`, `times
 
 Additional: `parentHash`, `nonce`, `sha3Uncles`, `logsBloom`, `transactionsRoot`, `stateRoot`, `receiptsRoot`, `miner`, `difficulty`, `totalDifficulty`, `extraData`, `size`, `gasLimit`, `gasUsed`, `uncles`, `baseFeePerGas`, `blobGasUsed`, `excessBlobGas`, `parentBeaconBlockRoot`, `withdrawalsRoot`, `l1BlockNumber`
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-troubleshooting/SKILL.md
+++ b/.claude/skills/indexer-troubleshooting/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: indexer-troubleshooting
+description: >-
+  Use when the indexer fails to start, codegen errors, types are stale,
+  Docker or database issues, RPC errors, or something is not working.
+  Common error messages and fixes.
+metadata:
+  managed-by: envio
+---
+
+# Troubleshooting
+
+## Stale Types / Codegen Issues
+
+**Symptom:** Type errors after editing `schema.graphql` or `config.yaml`.
+
+```bash
+pnpm codegen
+```
+
+Always run codegen after any schema or config change.
+
+## Docker / Database Not Running
+
+**Symptom:** `pnpm dev` fails with connection refused or database errors.
+
+```bash
+docker info  # check Docker is running
+```
+
+The indexer needs Docker for PostgreSQL. Start Docker and retry.
+
+## Environment Variables
+
+All env vars MUST use the `ENVIO_` prefix. The hosted service only exposes variables with this prefix at runtime.
+
+```yaml
+# WRONG
+rpc:
+  - url: ${RPC_URL}
+
+# CORRECT
+rpc:
+  - url: ${ENVIO_RPC_URL}
+```
+
+## RPC / HyperSync Errors
+
+**"rate limited" or timeout errors:** See `indexer-performance` skill for RPC tuning parameters.
+
+**Missing `ENVIO_API_TOKEN`:** Required for HyperSync. Get an Envio API token at https://envio.dev/app/api-tokens, then set it in `.env` or shell environment.
+
+## Common Runtime Errors
+
+**"field not indexed"** — `getWhere` only works on `id` and fields with `@index` in `schema.graphql`.
+
+**"entity is read-only"** — Entities from `context.Entity.get()` are frozen. Spread to update: `context.Entity.set({ ...entity, field: newValue })`.
+
+**"Cannot find module 'envio'"** — Run `pnpm install`.
+
+**Codegen output stale after `config.yaml` change** — Run `pnpm codegen` again.

--- a/.claude/skills/indexer-wildcard/SKILL.md
+++ b/.claude/skills/indexer-wildcard/SKILL.md
@@ -67,6 +67,4 @@ indexer.onEvent(
 );
 ```
 
-## Deep Documentation
-
-Full reference: https://docs.envio.dev/docs/HyperIndex-LLM/hyperindex-complete
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "envio": "^3.0.2",
+    "envio": "3.2.1",
     "viem": "^2.46.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: ^3.0.2
-        version: 3.0.2(react-dom@19.2.7(react@19.2.5))(typescript@6.0.3)
+        specifier: 3.2.1
+        version: 3.2.1(react-dom@19.2.7(react@19.2.5))(typescript@6.0.3)
       viem:
         specifier: ^2.46.2
         version: 2.46.2(typescript@6.0.3)
@@ -39,6 +39,7 @@ packages:
 
   '@clickhouse/client-common@1.17.0':
     resolution: {integrity: sha512-MiwwgXViFAQA2YZkN4ymF1ynzG0K49KeSX9/iOcmJetWkxqSekDdpyp1GjwATWa9R215uQ+hGzJtJujeQVZZIw==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.17.0':
     resolution: {integrity: sha512-Y3DQoamKZ/Iyosoq7Lj7lqpDkQDK4R/5mI52yJs4ZLPIO+d6/CYDqTbFBIb4No3C/AlXUYE4TKhj/kXDpe6rOA==}
@@ -102,43 +103,6 @@ packages:
 
   '@envio-dev/hyperfuel-client@1.2.2':
     resolution: {integrity: sha512-raKA6DshYSle0sAOHBV1OkSRFMN+Mkz8sFiMmS3k+m5nP6pP56E17CRRePBL5qmR6ZgSEvGOz/44QUiKNkK9Pg==}
-    engines: {node: '>= 10'}
-
-  '@envio-dev/hypersync-client-darwin-arm64@1.3.0':
-    resolution: {integrity: sha512-JZwiVRbMSuJnKsVUpfjTHc3YgAMvGlyuqWQxVc7Eok4Xp/sZLUCXRQUykbCh6fOUWRmoa2JG/ykP/NotoTRCBg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@envio-dev/hypersync-client-darwin-x64@1.3.0':
-    resolution: {integrity: sha512-2eSzQqqqFBMK2enVucYGcny5Ep4DEKYxf3Xme7z9qp2d3c6fMcbVvM4Gt8KOzb7ySjwJ2gU+qY2h545T2NiJXQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@envio-dev/hypersync-client-linux-arm64-gnu@1.3.0':
-    resolution: {integrity: sha512-gsjMp3WKekwnA89HvJXvcTM3BE5wVFG/qTF4rmk3rGiXhZ+MGaZQKrYRAhnzQZblueFtF/xnnBYpO35Z3ZFThg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hypersync-client-linux-x64-gnu@1.3.0':
-    resolution: {integrity: sha512-Lkvi4lRVwCyFOXf9LYH2X91zmW2l1vbfojKhTwKgqFWv6PMN5atlYjt+/NcUCAAhk5EUavWGjoikwnvLp870cg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hypersync-client-linux-x64-musl@1.3.0':
-    resolution: {integrity: sha512-UIjB/gUX2sl23EMXLBxqtkgMnOjNSiaHK+CSU5vXMXkzL3fOGbz24bvyaPsSv82cxCFEE0yTwlSKkCX6/L8o6Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@envio-dev/hypersync-client@1.3.0':
-    resolution: {integrity: sha512-wUdfZzbsFPbGq6n/1mmUMsWuiAil+m+fL/GBX5LGUyMJV86TXy2SBtAqYYNyDxWLO6gvGr6PYKrP8pLVAUZDZg==}
     engines: {node: '>= 10'}
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -492,9 +456,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/node@22.19.11':
-    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
-
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
@@ -744,36 +705,36 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.0.2:
-    resolution: {integrity: sha512-h5mbaTWqDTaTeC2TMOzdD7cd1RKhSjCf003Bw0IKfx+799+J+N3MbNylRIwJGxpUhs5mTeeVefe7S42bLmH4dw==}
+  envio-darwin-arm64@3.2.1:
+    resolution: {integrity: sha512-PohM1rGjlNxV0W/BOQOitsVPua944B2t2M0p81x9VpsZOwNWc9SgPsEjIsV4ZJOIceJaHrmWZnfwaWubgDGKMg==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.0.2:
-    resolution: {integrity: sha512-OWHh3kgz+aMnjD5yIDb2CbFGNz3o+Hhkj1GMijNAyqtwAmKNhFEIDPb7RPu5VnHpq0ydLwhSHJI1gER27vZBrw==}
+  envio-darwin-x64@3.2.1:
+    resolution: {integrity: sha512-70zjTm4tNFzhigja0mHqmG03JQu56e9JCTQR7zoEhVvwj47cSgAPmQIihpaPuDCcMIYibzrlW7pFKdnXAZp3fQ==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.0.2:
-    resolution: {integrity: sha512-Y16qjfTR36qb/+52eomBYO8Zbr1GZRalIF/bl33TwDiQ9mdqExgf2qAEr0q5JLoRansEudO5H1yzTXDo7YuU1w==}
+  envio-linux-arm64@3.2.1:
+    resolution: {integrity: sha512-OOVnX+aM8xJ5zYBmpqzSVCX5KFU+wi1gSfbv9X+nXk1rLjicHGm5U847oDmYBF5iyxkJDQBMsW9sr+7X4g8Yhg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.0.2:
-    resolution: {integrity: sha512-JA+GkfQHg8j4GuiU3s0QrmnHX27Gd2fasIxetJQruzrxMgmRxuqJZbAqARyG5iWbRNnIC7Ml4gu2jLjtepC6Hg==}
+  envio-linux-x64-musl@3.2.1:
+    resolution: {integrity: sha512-/0lWrS/l2VYwdx7t0QvBE8b1R2vsnWpgi2q2xWqSmyOI9SOPU1q9YUElkhaDQFHEUXvqzyDDZPqxQacFtJggXw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  envio-linux-x64@3.0.2:
-    resolution: {integrity: sha512-Z9MFRNNBPZ0jvBBuT53thBTXrBZw9Jg4fd9ldldcEG84Xa1JQKqyEDte/zrSg09nFh0LtvjeyaxZLLfJRY/Ncg==}
+  envio-linux-x64@3.2.1:
+    resolution: {integrity: sha512-YACCs+YdemYj4KBYOw/o6fi3hofAWrJ8VOeCwaOWEAzlqQxqkZ6h3O7puZWLnmjgdJvBAReUikFxI+E9MiyHOQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  envio@3.0.2:
-    resolution: {integrity: sha512-Xl4DgVSqxKEaRn12Jxt7s6gDi3Y2x1CwTh9f28m4c9Rwd4STG4ZcmqHVQJp0u2jAz6eITHS5VRnsjXlyRhbRzQ==}
+  envio@3.2.1:
+    resolution: {integrity: sha512-mPvVeomNzi3pz7KqBEpfaiVM8JKZzNphAipT47KiTB+HUrvuMBGmqODgLYUJqQ+iJxiRuCqOVNDy8oCMsZjfwg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1492,9 +1453,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -1723,29 +1681,6 @@ snapshots:
       '@envio-dev/hyperfuel-client-linux-x64-musl': 1.2.2
       '@envio-dev/hyperfuel-client-win32-x64-msvc': 1.2.2
 
-  '@envio-dev/hypersync-client-darwin-arm64@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-darwin-x64@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-linux-arm64-gnu@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-linux-x64-gnu@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-linux-x64-musl@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client@1.3.0':
-    optionalDependencies:
-      '@envio-dev/hypersync-client-darwin-arm64': 1.3.0
-      '@envio-dev/hypersync-client-darwin-x64': 1.3.0
-      '@envio-dev/hypersync-client-linux-arm64-gnu': 1.3.0
-      '@envio-dev/hypersync-client-linux-x64-gnu': 1.3.0
-      '@envio-dev/hypersync-client-linux-x64-musl': 1.3.0
-
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -1967,7 +1902,7 @@ snapshots:
 
   '@types/bn.js@5.2.0':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.12.4
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1977,10 +1912,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
-
-  '@types/node@22.19.11':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@24.12.4':
     dependencies:
@@ -2205,27 +2136,26 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.0.2:
+  envio-darwin-arm64@3.2.1:
     optional: true
 
-  envio-darwin-x64@3.0.2:
+  envio-darwin-x64@3.2.1:
     optional: true
 
-  envio-linux-arm64@3.0.2:
+  envio-linux-arm64@3.2.1:
     optional: true
 
-  envio-linux-x64-musl@3.0.2:
+  envio-linux-x64-musl@3.2.1:
     optional: true
 
-  envio-linux-x64@3.0.2:
+  envio-linux-x64@3.2.1:
     optional: true
 
-  envio@3.0.2(react-dom@19.2.7(react@19.2.5))(typescript@6.0.3):
+  envio@3.2.1(react-dom@19.2.7(react@19.2.5))(typescript@6.0.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
       '@envio-dev/hyperfuel-client': 1.2.2
-      '@envio-dev/hypersync-client': 1.3.0
       '@fuel-ts/crypto': 0.96.1
       '@fuel-ts/errors': 0.96.1
       '@fuel-ts/hasher': 0.96.1
@@ -2252,11 +2182,11 @@ snapshots:
       viem: 2.46.2(typescript@6.0.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.0.2
-      envio-darwin-x64: 3.0.2
-      envio-linux-arm64: 3.0.2
-      envio-linux-x64: 3.0.2
-      envio-linux-x64-musl: 3.0.2
+      envio-darwin-arm64: 3.2.1
+      envio-darwin-x64: 3.2.1
+      envio-linux-arm64: 3.2.1
+      envio-linux-x64: 3.2.1
+      envio-linux-x64-musl: 3.2.1
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -2999,8 +2929,6 @@ snapshots:
       mime-types: 2.1.35
 
   typescript@6.0.3: {}
-
-  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 

--- a/src/EventHandlers.ts
+++ b/src/EventHandlers.ts
@@ -1,3 +1,4 @@
+import { indexer } from "envio";
 /**
  * Main entry point for all Envio/HyperIndex event handlers.
  *

--- a/src/arbitrum-polling.ts
+++ b/src/arbitrum-polling.ts
@@ -1,5 +1,5 @@
-import { indexer } from 'envio';
-import type { Entity, EvmOnEventContext } from 'envio';
+import { indexer } from "envio";
+import type { Entity, EvmOnEventContext } from "envio";
 
 type ArbitrumVoter = Entity<'ArbitrumVoter'>;
 

--- a/src/curveUsdsStUsdsPool.ts
+++ b/src/curveUsdsStUsdsPool.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 import { readCurvePoolCoinEffect } from './helpers/contractCalls';
 
 indexer.onEvent({ contract: 'CurveUsdsStUsdsPool', event: 'TokenExchange' }, async ({ event, context }) => {

--- a/src/dai-usds.ts
+++ b/src/dai-usds.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'DaiUsds', event: 'DaiToUsds' }, async ({ event, context }) => {
   const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;

--- a/src/delegate-factory-v2.ts
+++ b/src/delegate-factory-v2.ts
@@ -1,4 +1,4 @@
-import { indexer, BigDecimal } from 'envio';
+import { indexer, BigDecimal } from "envio";
 
 // Register dynamic contract for VoteDelegateV2 when CreateVoteDelegate is emitted
 indexer.contractRegister(

--- a/src/delegate-factory-v3.ts
+++ b/src/delegate-factory-v3.ts
@@ -1,4 +1,4 @@
-import { indexer, BigDecimal } from 'envio';
+import { indexer, BigDecimal } from "envio";
 
 // Register dynamic contract for VoteDelegateV3 when CreateVoteDelegate is emitted
 indexer.contractRegister(

--- a/src/delegate-factory.ts
+++ b/src/delegate-factory.ts
@@ -1,4 +1,4 @@
-import { indexer, BigDecimal } from 'envio';
+import { indexer, BigDecimal } from "envio";
 
 // Register dynamic contract for VoteDelegate when CreateVoteDelegate is emitted
 indexer.contractRegister(

--- a/src/ds-chief-v2.ts
+++ b/src/ds-chief-v2.ts
@@ -1,5 +1,5 @@
-import { indexer } from 'envio';
-import type { EvmEvent, EvmOnEventContext } from 'envio';
+import { indexer } from "envio";
+import type { EvmEvent, EvmOnEventContext } from "envio";
 import { SpellState } from './helpers/constants';
 import {
   addWeightToSpellsV2,

--- a/src/helpers/contractCalls.ts
+++ b/src/helpers/contractCalls.ts
@@ -6,7 +6,7 @@ import {
 } from 'viem';
 import { mainnet } from 'viem/chains';
 import type { Chain } from 'viem';
-import { createEffect, S } from 'envio';
+import { createEffect, S } from "envio";
 
 // ABI fragments for the contract calls we need
 const dsChiefSlatesAbi = [

--- a/src/helpers/delegates/index.ts
+++ b/src/helpers/delegates/index.ts
@@ -1,4 +1,4 @@
-import type { Entity, EvmOnEventContext } from 'envio';
+import type { Entity, EvmOnEventContext } from "envio";
 import { shouldIgnoreDelegator } from '../constants';
 
 type Delegate = Entity<'Delegate'>;

--- a/src/helpers/getReward.ts
+++ b/src/helpers/getReward.ts
@@ -1,4 +1,4 @@
-import type { EvmOnEventContext, Entity } from 'envio';
+import type { EvmOnEventContext, Entity } from "envio";
 
 type Reward = Entity<'Reward'>;
 

--- a/src/helpers/getSealUrn.ts
+++ b/src/helpers/getSealUrn.ts
@@ -1,4 +1,4 @@
-import type { EvmOnEventContext, Entity } from 'envio';
+import type { EvmOnEventContext, Entity } from "envio";
 import { ZERO_ADDRESS } from './constants';
 
 type SealUrn = Entity<'SealUrn'>;

--- a/src/helpers/getStakingEngineUrn.ts
+++ b/src/helpers/getStakingEngineUrn.ts
@@ -1,4 +1,4 @@
-import type { EvmOnEventContext, Entity } from 'envio';
+import type { EvmOnEventContext, Entity } from "envio";
 import { ZERO_ADDRESS } from './constants';
 
 type StakingUrn = Entity<'StakingUrn'>;

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,5 +1,5 @@
-import { BigDecimal } from 'envio';
-import type { Entity, EvmEvent, EvmOnEventContext } from 'envio';
+import { BigDecimal } from "envio";
+import type { Entity, EvmEvent, EvmOnEventContext } from "envio";
 import {
   readDSChiefSlateEffect,
   readSpellDescriptionEffect,

--- a/src/indexer.test.ts
+++ b/src/indexer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createTestIndexer } from 'envio';
+import { createTestIndexer } from "envio";
 import './EventHandlers';
 
 const CALLER = '0x1111111111111111111111111111111111111111';

--- a/src/lite-psm.ts
+++ b/src/lite-psm.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 // Mainnet token addresses
 const USDC_MAINNET = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';

--- a/src/lockstake-clipper.ts
+++ b/src/lockstake-clipper.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'LockstakeClipper', event: 'Rely' }, async ({ event, context }) => {
   const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;

--- a/src/lockstake-mkr.ts
+++ b/src/lockstake-mkr.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'LockstakeMkr', event: 'LockstakeMkrRely' }, async ({ event, context }) => {
   const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;

--- a/src/mcd-dog.ts
+++ b/src/mcd-dog.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'McdDog', event: 'Bark' }, async ({ event, context }) => {
   const barkId = `${event.chainId}-${event.params.ilk}-${event.params.id}`;

--- a/src/mkr-sky-v2.ts
+++ b/src/mkr-sky-v2.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'MkrSkyV2', event: 'MkrToSky' }, async ({ event, context }) => {
   const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;

--- a/src/mkr-sky.ts
+++ b/src/mkr-sky.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'MkrSky', event: 'MkrToSky' }, async ({ event, context }) => {
   const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;

--- a/src/polling-emitter.ts
+++ b/src/polling-emitter.ts
@@ -1,5 +1,5 @@
-import { indexer } from 'envio';
-import type { EvmEvent, EvmOnEventContext } from 'envio';
+import { indexer } from "envio";
+import type { EvmEvent, EvmOnEventContext } from "envio";
 import { getVoter } from './helpers/helpers';
 
 // Helper: create a default Poll entity with all required fields

--- a/src/psm3.ts
+++ b/src/psm3.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'Psm3', event: 'Swap' }, async ({ event, context }) => {
   const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;

--- a/src/rewards.ts
+++ b/src/rewards.ts
@@ -1,5 +1,5 @@
-import { indexer } from 'envio';
-import type { EvmOnEventContext, EvmEvent, Entity } from 'envio';
+import { indexer } from "envio";
+import type { EvmOnEventContext, EvmEvent, Entity } from "envio";
 
 type Reward = Entity<'Reward'>;
 

--- a/src/savings-usds.ts
+++ b/src/savings-usds.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'SavingsUsds', event: 'Deposit' }, async ({ event, context }) => {
   const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;

--- a/src/seal.ts
+++ b/src/seal.ts
@@ -1,4 +1,4 @@
-import { indexer, type Entity } from 'envio';
+import { indexer, type Entity } from "envio";
 import { getSealUrn } from './helpers/getSealUrn';
 import {
   getDelegate,

--- a/src/staking-engine.ts
+++ b/src/staking-engine.ts
@@ -1,4 +1,4 @@
-import { indexer, type Entity } from 'envio';
+import { indexer, type Entity } from "envio";
 import { getStakingEngineUrn } from './helpers/getStakingEngineUrn';
 import {
   getDelegate,

--- a/src/stusds.ts
+++ b/src/stusds.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'Stusds', event: 'Deposit' }, async ({ event, context }) => {
   const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;

--- a/src/susdt.ts
+++ b/src/susdt.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 
 indexer.onEvent({ contract: 'Susdt', event: 'Deposit' }, async ({ event, context }) => {
   const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;

--- a/src/vote-delegate-v2.ts
+++ b/src/vote-delegate-v2.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 import { shouldIgnoreDelegator } from './helpers/constants';
 
 indexer.onEvent({ contract: 'VoteDelegateV2', event: 'Lock' }, async ({ event, context }) => {

--- a/src/vote-delegate-v3.ts
+++ b/src/vote-delegate-v3.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 import { shouldIgnoreDelegator } from './helpers/constants';
 
 indexer.onEvent({ contract: 'VoteDelegateV3', event: 'Lock' }, async ({ event, context }) => {

--- a/src/vote-delegate.ts
+++ b/src/vote-delegate.ts
@@ -1,4 +1,4 @@
-import { indexer } from 'envio';
+import { indexer } from "envio";
 import { shouldIgnoreDelegator } from './helpers/constants';
 
 indexer.onEvent({ contract: 'VoteDelegate', event: 'Lock' }, async ({ event, context }) => {


### PR DESCRIPTION
## Summary
- Upgrade `envio` (HyperIndex) to **3.2.1**
- Migrate config/handlers to the V3 API where needed (`networks` -> `chains`, `indexer.onEvent`, imports from `envio`, etc.)
- Refresh bundled agent skills via `envio skills update` (under `.claude/skills/`)

## Context
This indexer is deployed on Envio's hosted service. Merging this PR makes it straightforward to redeploy on 3.2.1.

## Test plan
- [ ] `pnpm install`
- [ ] `pnpm envio codegen`
- [ ] `pnpm dev` (or hosted redeploy) and confirm indexing starts
